### PR TITLE
Add Wireguard to postmarketOS configuration

### DIFF
--- a/kernel/configs/pmos.config
+++ b/kernel/configs/pmos.config
@@ -22,3 +22,6 @@ CONFIG_TMPFS_POSIX_ACL=y
 
 # fbkeyboard
 CONFIG_INPUT_UINPUT=y
+
+# Wireguard
+CONFIG_WIREGUARD=m


### PR DESCRIPTION
Requested in https://gitlab.com/postmarketOS/pmaports/-/issues/1109

This does depend on some other configs — are dependencies automatically resolved for things enabled here?

Edit: Wrong repo :man_facepalming: 